### PR TITLE
disable Skill until new API implemented

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,8 +20,12 @@ from mycroft import MycroftSkill, intent_handler
 
 
 class StockSkill(MycroftSkill):
-    @intent_handler(IntentBuilder("") \
-            .require("StockPriceKeyword").require("Company"))
+    def __init__(self):
+        super().__init__()
+        raise Exception('Skill has been disabled by Mycroft')
+
+    # @intent_handler(IntentBuilder("") \
+    #         .require("StockPriceKeyword").require("Company"))
     def handle_stock_price_intent(self, message):
         company = message.data.get("Company")
         try:


### PR DESCRIPTION
As reported in #19 the markitondemand.com API is no longer operational.

Until a new API is selected and implemented, this will disable the Skill. The exception will prevent it from loading, and just in case the `@intent_handler` decorator has been commented out so the intent can't be registered.