### PR TITLE
Fix issue #27 - some company names not matching

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,6 +14,7 @@
 
 import time
 import requests
+from urllib.parse import quote_plus
 
 from adapt.intent import IntentBuilder
 from mycroft import MycroftSkill, intent_handler
@@ -33,7 +34,7 @@ PROFILE_QUERY = API_URL + 'company/profile/{}'
 
 def search_company(query):
     """Search for a company and return the ticker symbol."""
-    lookup = requests.get(SEARCH_QUERY.format(query))
+    lookup = requests.get(SEARCH_QUERY.format(quote_plus(query)))
     if 200 <= lookup.status_code < 300:
         if len(lookup.json()) == 0:
             return None # Nothing found

--- a/__init__.py
+++ b/__init__.py
@@ -40,9 +40,10 @@ def search_company(query):
             # Create dict with company name as key
             company_dict = {c['name'].lower(): c for c in lookup.json()}
             info, confidence = match_one(query.lower(), company_dict)
-            # Return None if the confidence is too low otherwise
-            # return the closest match.
-            return info['symbol'] if confidence > 0.5 else None
+            # Return result if confidence is high enough, or query string 
+            # contained in company name eg Cisco > Cisco Systems
+            if confidence > 0.5 or query.lower() in info['name'].lower():
+                return info['symbol']
     else:
         # HTTP Status indicates something went wrong
         raise requests.HTTPError('API returned status code: '

--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,8 @@ from mycroft.util.parse import match_one
 
 
 COMPANY_ALIASES = {
-    'google': 'Alphabet inc'
+    'google': 'Alphabet inc',
+    'ibm': 'International Business Machines'
 }
 
 # These are the endpoints for the financial modeling prep open API
@@ -40,7 +41,7 @@ def search_company(query):
             # Create dict with company name as key
             company_dict = {c['name'].lower(): c for c in lookup.json()}
             info, confidence = match_one(query.lower(), company_dict)
-            # Return result if confidence is high enough, or query string 
+            # Return result if confidence is high enough, or query string
             # contained in company name eg Cisco > Cisco Systems
             if confidence > 0.5 or query.lower() in info['name'].lower():
                 return info['symbol']

--- a/test/behave/stock.feature
+++ b/test/behave/stock.feature
@@ -5,8 +5,16 @@ Feature: mycroft-stock
      When the user says "what price is microsoft trading at"
      Then "mycroft-stock" should reply with dialog from "stock.price.dialog"
 
-  Scenario: stock price of microsoft
+  Scenario Outline: stock price of microsoft
     Given an english speaking user
-     When the user says "what is the stock price of microsoft"
+     When the user says "what is the stock price of <some company>"
      Then "mycroft-stock" should reply with dialog from "stock.price.dialog"
 
+    Examples:
+      | some company |
+      | microsoft |
+      | at&t |
+      | google |
+      | ibm |
+      | cisco |
+      | apple |


### PR DESCRIPTION
This is really three issues - added tests to cover broader range of companies:

### Shortened names not matching
Shortened company names were not matching the ticker as they didn't meet the confidence threshold of 0.5. If the query string is wholly contained within the company name this should also match.

#### To test
"stock price of altria" > "Altria Group" 
"stock price of Appian"  > "Appian Corporation" 
"stock price of Cisco > "Cisco Systems" 
"stock price of Fidelity > "Fidelity Financial" 
"stock price of Ford > "Ford Motor" 
"stock price of Verizon > "Verizon Communications" 

### IBM needed an alias
Added alias for IBM

#### To test
"stock price of IBM > "International Business Machines" 

### Special characters not urlencoded in API request
encode any special characters such as '&' before including in the API request

#### To test
"stock price of at&t" 